### PR TITLE
Allow to override the default CHUNK

### DIFF
--- a/zipflow.c
+++ b/zipflow.c
@@ -23,10 +23,12 @@
 
 // Input and output buffer sizes for deflate. Twice this will be allocated on
 // the stack for compression.
+#ifndef CHUNK
 #if UINT_MAX < 4294967295
 #  define CHUNK 32768
 #else
 #  define CHUNK 262144
+#endif
 #endif
 
 // Information on each entry saved for the central directory. This takes up 56


### PR DESCRIPTION
I am delighted to find this new project, because, so far, it does exactly what I need, and I would have started something similar had I not found it. Thank you!
I am working on a [varnish-cache](https://varnish-cache.org/) [module](https://varnish-cache.org/vmods/) to wrap your code as a filter. The first issue I noticed was a stack overflow, because we like our stacks to be rather small (80kb default on 64bit, 64kb on 32bit).
This PR is to allow overrides `CHUNK` to make a smaller stack footprint possible.