### PR TITLE
Sync comment with reality

### DIFF
--- a/zipflow.c
+++ b/zipflow.c
@@ -241,10 +241,9 @@ static void zip_local(zip_t *zip) {
 
 // Compress the file in using deflate, writing the compressed data to zip->out.
 // Set the saved header fields for the uncompressed and compressed lengths, and
-// the CRC-32 computed on the uncompressed data. The input and output buffers
-// for deflation are allocated on the stack. If a write error is encountered,
-// the deflation process is abandoned, since the result won't be going anywhere
-// anyway.
+// the CRC-32 computed on the uncompressed data. If a write error is
+// encountered, the deflation process is abandoned, since the result won't be
+// going anywhere anyway.
 static void zip_deflate(zip_t *zip, FILE *in) {
     head_t *head = zip->head + zip->hnum;
     head->ulen = 0;


### PR DESCRIPTION
Since b334fdbabeec43cab0c9830c0f74c0432a1c62df, the buffers are no longer allocated on the stack.