### PR TITLE
Change put() callback signature to inform about ptr validity

### DIFF
--- a/zipflow.h
+++ b/zipflow.h
@@ -68,7 +68,8 @@
 // Instead of writing to a file, an output function can be registered by using
 // zip_pipe() instead of zip_open():
 //
-//      int put(void *handle, void const *ptr, size_t len) {
+//      int put(void *handle, void const *ptr, size_t len, int flag) {
+//          void (flag); // see zip_pipe()
 //          return fwrite(ptr, 1, len, (FILE *)handle) < len;
 //      }
 //      ZIP *zip = zip_pipe(stdout, put, level);
@@ -120,15 +121,18 @@ typedef void ZIP;           // opaque structure for zip streaming operations
 // range.
 ZIP *zip_open(FILE *out, int level);
 
-// Like zip_open(), but instead of a FILE *, register the function put() for
-// the streaming zip file output. put() accepts the len bytes at ptr. If ptr is
-// NULL, then the streaming has completed, and put() may flush the output.
-// put() returns 0 on success, or 1 to abort the streaming. If put() returns 1,
-// it will not be called again for that ZIP * instance. No error message is
-// issued in that case. A pointer to the zip state is returned on success. NULL
-// is returned if put is NULL or level is out of range.
+// Like zip_open(), but instead of a FILE *, register the function put() for the
+// streaming zip file output. put() accepts the len bytes at ptr. If flag is 0,
+// the current ptr remains valid and put() does not need to process it
+// immediately. If flag is 1, ptr and/or ptr from any any previous call will go
+// out of scope and put() needs to finish all processing of them. If flag is 2,
+// this is the last call to put() for this ZIP * instance.  put() returns 0 on
+// success, or 1 to abort the streaming. If put() returns 1, it will not be
+// called again for that ZIP * instance. No error message is issued in that
+// case. A pointer to the zip state is returned on success. NULL is returned if
+// put is NULL or level is out of range.
 ZIP *zip_pipe(void *handle,
-              int (*put)(void *handle, void const *ptr, size_t len),
+              int (*put)(void *handle, void const *ptr, size_t len, int flag),
               int level);
 
 // Register the function log() to intercept warning and error messages. msg is


### PR DESCRIPTION
As hinted by the last paragraph of the commit message given below, I would continue working on optimizations enabled by this change, if accepted.

----

Before this patch, the implied assumption was that the `put()` `ptr` argument was only valid for that particular call, so a `put()` implementation had to either write the data immediately or buffer it.

The end of the zip file was signaled through a `NULL` `ptr` argument, so the `put()` implementation had no way of efficiently handling the last bit of data.

This patch introduces a breaking signature change of the `put()` function: A `flag` argument is added, which takes one of three values depending on the validity of the `ptr` argument:

* `0`: `ptr` remains valid until after this call
* `1`: `ptr` or any `ptr` from a previous call will become invalid after this call
* `2`: this is the last `ptr` of the file

This allows `put()` implementations to avoid buffering and optimize handling of the last bytes of the zip file.

Note that with this patch, the implementation still misses optimizations enabled through this change, for example, after a `deflate(Z_FINISH)`, `zip->comp` remains valid until the next call, so we might be able to use `flag = 0` here.