### PR TITLE
Initialize strm.avail_in in zip_data()

### DIFF
--- a/zipflow.c
+++ b/zipflow.c
@@ -795,6 +795,7 @@ int zip_data(ZIP *ptr, void const *data, size_t len, int last) {
 
     // Compress the data to the output stream, updating the compressed length.
     zip->strm.next_in = (unsigned char *)(uintptr_t)data;   // awful hack
+    zip->strm.avail_in = 0;
     int ret;
     do {
         if (zip->strm.avail_in == 0) {


### PR DESCRIPTION
This looks like an oversight from c4622bfba95577a24e34112934afffeb3cc2f822:

For zip_data(), the initialization was missed, while it exists for zip_deflate(). This could lead to an out-of-bounds access which, ideally, would trigger a segmentation violation, but could potentially add arbitrary data.